### PR TITLE
Cross-build for 2.11

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ name := projectName
 
 organization := "com.github.jarlakxen"
 
-crossScalaVersions := Seq("2.12.5")
+crossScalaVersions := Seq("2.12.7", "2.11.12")
 
 scalaVersion := crossScalaVersions.value.head
 


### PR DESCRIPTION
Hi @Jarlakxen,

it would be great if you could cross-publish for 2.11.
I'd like to try drunk in a Spark-based project and therefore can't use 2.12 yet.