### PR TITLE
Update Akka to 2.6.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ name := projectName
 
 organization := "com.github.jarlakxen"
 
-crossScalaVersions := Seq("2.12.7", "2.11.12")
+crossScalaVersions := Seq("2.13.1", "2.12.9")
 
 scalaVersion := crossScalaVersions.value.head
 
@@ -41,14 +41,14 @@ scalacOptions ++= Seq(
 resolvers ++= Seq(Resolver.sonatypeRepo("releases"), Resolver.sonatypeRepo("snapshots"))
 
 // ··· Project Dependencies ···
-val sangriaV        = "1.4.+"
-val sangriaCirceV   = "1.2.1"
-val akkaHttpV       = "10.1.+"
-val akkaHttpCircleV = "1.22.+"
-val circeV          = "0.10.+"
+val sangriaV        = "2.0.0-M1"
+val sangriaCirceV   = "1.3.0"
+val akkaHttpV       = "10.1.10"
+val akkaHttpCircleV = "1.28.+"
+val circeV          = "0.12.1"
 val slf4JV          = "1.7.25"
 val logbackV        = "1.2.3"
-val scalatestV      = "3.0.5"
+val scalatestV      = "3.0.8"
 
 libraryDependencies ++= Seq(
   // --- GraphQL --
@@ -64,6 +64,7 @@ libraryDependencies ++= Seq(
   "org.slf4j"           %  "slf4j-api"        % slf4JV,
   "ch.qos.logback"      %  "logback-classic"  % logbackV        % Test,
   // --- Testing ---
+  "com.typesafe.akka"   %% "akka-testkit"       % "2.5.25"      % Test,
   "com.typesafe.akka"   %% "akka-http-testkit"  % akkaHttpV     % Test,
   "org.scalatest"       %% "scalatest"          % scalatestV    % Test
 )

--- a/build.sbt
+++ b/build.sbt
@@ -41,12 +41,12 @@ scalacOptions ++= Seq(
 resolvers ++= Seq(Resolver.sonatypeRepo("releases"), Resolver.sonatypeRepo("snapshots"))
 
 // ··· Project Dependencies ···
-val sangriaV        = "2.0.0-M1"
+val sangriaV        = "2.0.0-M3"
 val sangriaCirceV   = "1.3.0"
-val akkaHttpV       = "10.1.10"
-val akkaHttpCircleV = "1.28.+"
-val circeV          = "0.12.1"
-val slf4JV          = "1.7.25"
+val akkaHttpV       = "10.1.11"
+val akkaHttpCircleV = "1.30.+"
+val circeV          = "0.12.3"
+val slf4JV          = "1.7.30"
 val logbackV        = "1.2.3"
 val scalatestV      = "3.0.8"
 
@@ -64,7 +64,7 @@ libraryDependencies ++= Seq(
   "org.slf4j"           %  "slf4j-api"        % slf4JV,
   "ch.qos.logback"      %  "logback-classic"  % logbackV        % Test,
   // --- Testing ---
-  "com.typesafe.akka"   %% "akka-testkit"       % "2.5.25"      % Test,
+  "com.typesafe.akka"   %% "akka-testkit"       % "2.6.1"      % Test,
   "com.typesafe.akka"   %% "akka-http-testkit"  % akkaHttpV     % Test,
   "org.scalatest"       %% "scalatest"          % scalatestV    % Test
 )

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.6
+sbt.version=1.3.4

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -9,3 +9,5 @@ addSbtPlugin("org.foundweekends"  % "sbt-bintray"  % "0.5.4")
 // addSbtPlugin("ch.epfl.scala"     % "sbt-scalafix"  % "0.5.7")
 
 addSbtPlugin("de.heikoseeberger" % "sbt-header"    % "5.0.0")
+
+addSbtPlugin("net.virtual-void"  % "sbt-dependency-graph" % "0.10.0-RC1")

--- a/src/main/scala/com/github/jarlakxen/drunk/GraphQLClient.scala
+++ b/src/main/scala/com/github/jarlakxen/drunk/GraphQLClient.scala
@@ -27,7 +27,7 @@ import backend.{AkkaBackend, AkkaConnectionBackend, AkkaHttpBackend}
 import extensions.{GraphQLExtensions, NoExtensions}
 import io.circe._
 import io.circe.parser._
-import sangria._
+import sangria.{ ast => _, _ }
 import sangria.ast.Document
 import sangria.introspection._
 import sangria.marshalling.circe._

--- a/src/main/scala/com/github/jarlakxen/drunk/GraphQLClient.scala
+++ b/src/main/scala/com/github/jarlakxen/drunk/GraphQLClient.scala
@@ -180,7 +180,6 @@ object GraphQLClient {
     headers: immutable.Seq[HttpHeader] = Nil
   ): GraphQLClient = {
     implicit val as: ActorSystem = ActorSystem("GraphQLClient")
-    implicit val mat: ActorMaterializer = ActorMaterializer()
     val backend = AkkaHttpBackend(Uri(uri), headers)
     new GraphQLClient(clientOptions, backend)
   }
@@ -190,7 +189,7 @@ object GraphQLClient {
     flow: Flow[HttpRequest, HttpResponse, Future[OutgoingConnection]],
     clientOptions: ClientOptions,
     headers: immutable.Seq[HttpHeader]
-  )(implicit as: ActorSystem, mat: ActorMaterializer): GraphQLClient =
+  )(implicit as: ActorSystem): GraphQLClient =
     new GraphQLClient(clientOptions, AkkaConnectionBackend(uri, flow, headers))
 
   private[GraphQLClient] def extractErrors(body: Json, statusCode: Int): Option[GraphQLResponseError] = {

--- a/src/main/scala/com/github/jarlakxen/drunk/backend/AkkaBackend.scala
+++ b/src/main/scala/com/github/jarlakxen/drunk/backend/AkkaBackend.scala
@@ -13,7 +13,6 @@ import scala.concurrent.{ExecutionContext, Future}
 
 trait AkkaBackend {
   implicit val as: ActorSystem
-  implicit val mat: ActorMaterializer
 
   def send(body: String): Future[(Int, String)]
 

--- a/src/main/scala/com/github/jarlakxen/drunk/backend/AkkaConnectionBackend.scala
+++ b/src/main/scala/com/github/jarlakxen/drunk/backend/AkkaConnectionBackend.scala
@@ -3,7 +3,6 @@ package com.github.jarlakxen.drunk.backend
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http.OutgoingConnection
 import akka.http.scaladsl.model._
-import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.{Flow, Sink, Source}
 
 import scala.collection.immutable
@@ -13,7 +12,7 @@ class AkkaConnectionBackend  private[AkkaConnectionBackend] (
   uri: Uri,
   flow: Flow[HttpRequest, HttpResponse, Future[OutgoingConnection]],
   headers: immutable.Seq[HttpHeader]
-)(override implicit val as: ActorSystem, override implicit val mat: ActorMaterializer)
+)(override implicit val as: ActorSystem)
    extends AkkaBackend {
 
   def send(body: String): Future[(Int, String)] = {
@@ -56,7 +55,7 @@ object AkkaConnectionBackend {
   def apply(uri: Uri,
              flow: Flow[HttpRequest, HttpResponse, Future[OutgoingConnection]],
              headers: immutable.Seq[HttpHeader] = Nil
-           )( implicit  as: ActorSystem,  mat: ActorMaterializer): AkkaConnectionBackend =
+           )(implicit  as: ActorSystem): AkkaConnectionBackend =
     new AkkaConnectionBackend(uri, flow, headers)
 
 }

--- a/src/main/scala/com/github/jarlakxen/drunk/backend/AkkaHttpBackend.scala
+++ b/src/main/scala/com/github/jarlakxen/drunk/backend/AkkaHttpBackend.scala
@@ -21,13 +21,12 @@ import scala.concurrent.{ExecutionContext, Future}
 import akka.actor.ActorSystem
 import akka.http.scaladsl.{Http, HttpExt}
 import akka.http.scaladsl.model.{ContentTypes, HttpEntity, HttpHeader, HttpMethods, HttpRequest, Uri}
-import akka.stream.ActorMaterializer
 
 class AkkaHttpBackend private[AkkaHttpBackend] (
   uri: Uri,
   headers: immutable.Seq[HttpHeader],
   httpExt: HttpExt
-)(override implicit val as: ActorSystem, override implicit val mat: ActorMaterializer)
+)(override implicit val as: ActorSystem)
     extends AkkaBackend {
 
   def send(body: String): Future[(Int, String)] = {
@@ -67,7 +66,7 @@ object AkkaHttpBackend {
     uri: Uri,
     headers: immutable.Seq[HttpHeader] = Nil,
     httpExt: Option[HttpExt] = None
-  )(implicit as: ActorSystem, mat: ActorMaterializer): AkkaHttpBackend = {
+  )(implicit as: ActorSystem): AkkaHttpBackend = {
 
     val http = httpExt.getOrElse { Http(as) }
     new AkkaHttpBackend(uri, headers, http)

--- a/src/main/scala/com/github/jarlakxen/drunk/extensions/cache.scala
+++ b/src/main/scala/com/github/jarlakxen/drunk/extensions/cache.scala
@@ -11,7 +11,7 @@ object cache {
   case class GraphQLCacheControlHint(path: List[String], maxAge: Long, scope: Option[GraphQLCacheControlScope.Value])
   case class GraphQLCacheControlExtension(version: Int, hints: List[GraphQLCacheControlHint])
 
-  implicit val cacheControlScopeDecoder: Decoder[GraphQLCacheControlScope.Value] = Decoder.enumDecoder(GraphQLCacheControlScope)
+  implicit val cacheControlScopeDecoder: Decoder[GraphQLCacheControlScope.Value] = Decoder.decodeEnumeration(GraphQLCacheControlScope)
   implicit val cacheControlHintDecoder: Decoder[GraphQLCacheControlHint] = deriveDecoder[GraphQLCacheControlHint]
   implicit val cacheControlExtensionDecoder: Decoder[GraphQLCacheControlExtension] = deriveDecoder[GraphQLCacheControlExtension]
 

--- a/src/test/scala/com/github/jarlakxen/drunk/GraphQLClientSpec.scala
+++ b/src/test/scala/com/github/jarlakxen/drunk/GraphQLClientSpec.scala
@@ -34,7 +34,7 @@ case class Droid(
 case class HeroQuery(hero: Character)
 
 class GraphQLClientSpec extends Spec with TestHttpServer {
-  implicit val episodeDecoder = Decoder.enumDecoder(Episode)
+  implicit val episodeDecoder = Decoder.decodeEnumeration(Episode)
   implicit val humanDecoder: Decoder[Human] = deriveDecoder
   implicit val droidDecoder: Decoder[Droid] = deriveDecoder
 

--- a/src/test/scala/com/github/jarlakxen/drunk/package.scala
+++ b/src/test/scala/com/github/jarlakxen/drunk/package.scala
@@ -23,7 +23,6 @@ package object drunk {
 
     implicit val system: ActorSystem = ActorSystem("drunk-test")
     implicit def executor = system.dispatcher
-    implicit val materializer = ActorMaterializer()
 
     private def temporaryServerAddress(interface: String = "127.0.0.1"): InetSocketAddress = {
       val serverSocket = ServerSocketChannel.open()

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "2.5.0"
+version in ThisBuild := "2.6.0"


### PR DESCRIPTION
Fixes compiler warnings regarding the ActorMaterializer.

Depends on the Scala 2.13 PR (#11 )